### PR TITLE
Fix parsing custom LDAP ports

### DIFF
--- a/mozldap.go
+++ b/mozldap.go
@@ -75,7 +75,7 @@ func NewClient(uri, username, password string, tlsconf *tls.Config, starttls boo
 }
 
 // format: ldaps://example.net:636/dc=example,dc=net
-const URIRE = "ldap(s)?://(.+):?([0-9]{1,5})?/(.+)"
+const URIRE = "ldap(s)?://([^:]+):?([0-9]{1,5})?/(.+)"
 const URIFORMAT = "ldaps://ldap.example.net:636/dc=example,dc=net"
 
 // ParseUri extracts connection parameters from a given URI and return a client
@@ -91,6 +91,7 @@ func ParseUri(uri string) (cli Client, err error) {
 	if fields == nil || len(fields) != 5 {
 		panic("failed to parse URI. format is " + URIFORMAT)
 	}
+
 	// tls or not depends on "s"
 	if fields[1] == "s" {
 		cli.UseTLS = true
@@ -108,7 +109,7 @@ func ParseUri(uri string) (cli Client, err error) {
 			cli.Port = 389
 		}
 	} else {
-		cli.Port, err = strconv.Atoi(fields[2])
+		cli.Port, err = strconv.Atoi(fields[3])
 		if err != nil {
 			panic("invalid port in uri. format is " + URIFORMAT)
 		}


### PR DESCRIPTION
The previous regexp was greedily parsing the port section of the input and including it in the hostname.
